### PR TITLE
Feature/11 목적지로 파티 검색

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -2,6 +2,7 @@ package com.wap.app2.gachitayo.controller.party;
 
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
+import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
 import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.service.party.PartyService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,11 @@ public class PartyController {
     @PostMapping("/{id}")
     public ResponseEntity<?> addStopoverToParty(@PathVariable("id") Long id, @RequestBody StopoverDto stopoverDto) {
         return partyService.addStopoverToParty(id, stopoverDto);
+    }
+
+    @PostMapping("/search")
+    public ResponseEntity<?> searchPartyWithLocation(@RequestBody PartySearchRequestDto requestDto) {
+        return partyService.searchPartyWithDestinationLocation(requestDto);
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/PartySearchRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/PartySearchRequestDto.java
@@ -1,0 +1,19 @@
+package com.wap.app2.gachitayo.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartySearchRequestDto {
+    @JsonProperty("lat")
+    private Double latitude;
+    @JsonProperty("lng")
+    private Double longitude;
+    private Double radius;
+}

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyRepository.java
@@ -2,6 +2,17 @@ package com.wap.app2.gachitayo.repository.party;
 
 import com.wap.app2.gachitayo.domain.party.Party;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
+    @Query(value = """
+        SELECT DISTINCT p.* From party p
+        JOIN stopover s ON p.id = s.party_id
+        JOIN location l ON s.location_id = l.id
+        WHERE s.stopover_type = 'DESTINATION' AND ST_Distance_Sphere(point(l.longitude, l.latitude), point(:lng, :lat)) <= :radius
+        """, nativeQuery = true)
+    List<Party> findPartiesWithRadius(@Param("lat") double lat, @Param("lng") double lng, @Param("radius") double radius);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -5,6 +5,7 @@ import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
+import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
 import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.dto.response.PartyResponseDto;
 import com.wap.app2.gachitayo.mapper.StopoverMapper;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -110,6 +112,24 @@ public class PartyService {
                 locationService.createOrGetLocation(stopoverDto.getLocation()) : null;
 
         return stopoverService.updateStopover(stopoverEntity, locationEntity, stopoverDto.getStopoverType());
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<?> searchPartyWithDestinationLocation(PartySearchRequestDto requestDto) {
+        List<Party> parties = partyRepository.findPartiesWithRadius(requestDto.getLatitude(), requestDto.getLongitude(), requestDto.getRadius());
+        List<PartyResponseDto> responseDtos = new ArrayList<>();
+        for(Party party : parties) {
+            responseDtos.add(
+                    PartyResponseDto.builder()
+                            .id(party.getId())
+                            .stopovers(toStopoverDto(party))
+                            .radius(party.getAllowRadius())
+                            .maxPerson(party.getMaxPerson())
+                            .genderOption(party.getGenderOption())
+                            .build()
+            );
+        }
+        return ResponseEntity.ok(responseDtos);
     }
 
     private ResponseEntity<PartyResponseDto> notFoundPartyResponseEntity(Long partyId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 

## 📝작업 내용

- 목적지 위치를 중심으로 n Km 반경 내 파티 검색

## 요청-응답 예제

|엔드포인트|메서드|
|----|----|
|`/api/party/search`|`POST`|

### RequestBody
```json
{
  "lat": 11.1111,
  "lng": 55.5555,
  "radius": 5000000.0
}
```
(테스트 데이터의 lat, lng 값의 차이가 너무 커서 검색 반경 km 가 엄청 크게 적용)
(ST_Distance_Sphere 시 약 3670 Km 나옴;;;)

### 응답 예제
- 있다면
```json
{
  [
    {
      "party_id": 2,
      "party_start": {...},
      ...
    },
   {
     ...
   },
  ]
}
```

## 테스트 

![목적지로 파티 검색 결과](https://github.com/user-attachments/assets/efd1b724-95f4-46fd-aa76-8937f955c6cd)
![목적지로 파티 검색 결과2](https://github.com/user-attachments/assets/551a4a30-46dd-4f14-8d57-24fbb0eb70a7)
![목적지로 파티 검색 결과3](https://github.com/user-attachments/assets/6b616c97-79d0-4551-9a77-f2991a14501e)

---
Closes: #11 