### PR TITLE
Fix/12 파티 생성 시 파티의 Stopover가 없어지는 문제

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -4,29 +4,30 @@ import com.wap.app2.gachitayo.Enum.LocationType;
 import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
+import com.wap.app2.gachitayo.dto.datadto.LocationDto;
 import com.wap.app2.gachitayo.repository.location.StopoverRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class StopoverService {
     private final StopoverRepository stopoverRepository;
+    private final LocationService locationService;
 
     @Transactional
-    public Stopover findOrCreateStopover(Location targetLocation, LocationType stopoverType) {
-        Optional<Stopover> existingStopover = stopoverRepository
-                .findByLocationAndStopoverType(targetLocation, stopoverType);
-        return existingStopover.orElseGet(() -> stopoverRepository.save(
-                Stopover.builder()
-                        .location(targetLocation)
-                        .stopoverType(stopoverType)
-                        .build()
-        ));
+    public Stopover createStopover(LocationDto locationDto, LocationType stopoverType) {
+        Location locationEntity = locationService.createOrGetLocation(locationDto);
+        Stopover newStopover = stopoverRepository
+                .save(Stopover.builder()
+                    .location(locationEntity)
+                    .stopoverType(stopoverType)
+                    .build());
+        locationService.updateStopover(newStopover.getLocation(), newStopover);
+        return newStopover;
     }
 
     @Transactional

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -37,8 +37,9 @@ public class StopoverService {
     }
 
     @Transactional
-    public ResponseEntity<?> updateStopover(Stopover stopover, Location location, LocationType stopoverType) {
-        if(!stopover.update(location, stopoverType)) {
+    public ResponseEntity<?> updateStopover(Stopover stopover, LocationDto locationDto, LocationType stopoverType) {
+        Location locationEntity = (locationDto != null) ? locationService.createOrGetLocation(locationDto) : null;
+        if(!stopover.update(locationEntity, stopoverType)) {
             return ResponseEntity.ok().body("no changed");
         }
 

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -1,6 +1,5 @@
 package com.wap.app2.gachitayo.service.party;
 
-import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
@@ -8,9 +7,7 @@ import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.dto.response.PartyResponseDto;
 import com.wap.app2.gachitayo.mapper.StopoverMapper;
-import com.wap.app2.gachitayo.repository.location.StopoverRepository;
 import com.wap.app2.gachitayo.repository.party.PartyRepository;
-import com.wap.app2.gachitayo.service.location.LocationService;
 import com.wap.app2.gachitayo.service.location.StopoverService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,20 +25,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PartyService {
     private final PartyRepository partyRepository;
-    private final LocationService locationService;
     private final StopoverService stopoverService;
     private final StopoverMapper stopoverMapper;
-    private final StopoverRepository stopoverRepository;
 
     @Transactional
     public ResponseEntity<PartyCreateResponseDto> createParty(PartyCreateRequestDto requestDto) {
-        Location startLocation = locationService.createOrGetLocation(requestDto.getStartLocation().getLocation());
-        Stopover startStopover = stopoverService.findOrCreateStopover(startLocation, requestDto.getStartLocation().getStopoverType());
-        locationService.updateStopover(startLocation, startStopover);
-
-        Location destLocation = locationService.createOrGetLocation(requestDto.getDestination().getLocation());
-        Stopover destStopover = stopoverService.findOrCreateStopover(destLocation, requestDto.getDestination().getStopoverType());
-        locationService.updateStopover(destLocation, destStopover);
+        Stopover startStopover = stopoverService.createStopover(requestDto.getStartLocation().getLocation(), requestDto.getStartLocation().getStopoverType());
+        Stopover destStopover = stopoverService.createStopover(requestDto.getDestination().getLocation(), requestDto.getDestination().getStopoverType());
 
         Party partyEntity = Party.builder()
                 .stopovers(List.of(startStopover, destStopover))
@@ -77,9 +67,7 @@ public class PartyService {
             return notFoundPartyResponseEntity(partyId);
         }
 
-        Location locationEntity = locationService.createOrGetLocation(requestDto.getLocation());
-        Stopover stopoverEntity = stopoverService.findOrCreateStopover(locationEntity, requestDto.getStopoverType());
-        locationService.updateStopover(locationEntity, stopoverEntity);
+        Stopover stopoverEntity = stopoverService.createStopover(requestDto.getLocation(), requestDto.getStopoverType());
 
         boolean isExist = partyEntity.getStopovers().stream()
                 .anyMatch(stopover -> stopover.getLocation().equals(stopoverEntity.getLocation()));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #12 

## 📝작업 내용

- 이제 파티 생성 및 파티에 Stopover 추가 시 중복된 데이터라도 정상 생성
- 업데이트 로직 내부 구조 변경
  - 기존: Stopover 만든 후 해당 Stopover 에서 Party 찾음
  - 현재: PartyId 로 Party 찾은 후 해당 Party의 Stopover를 업데이트
  - 따라서 타당 및 효율적

## 테스트 결과

![파티 생성 수정안 결과](https://github.com/user-attachments/assets/2b504f21-d726-4543-b6e9-ef719abae2c4)
![파티 생성 수정안 결과2](https://github.com/user-attachments/assets/fa06bce5-ac16-4390-abb7-252c6899ee8a)

### DB 결과

![파티 생성 수정안 DB 결과](https://github.com/user-attachments/assets/e481b5a2-3677-4297-a802-7cff8986a1cc)

- 빨간색 상자: 문제가 되었던 생성 방식
- 초록색 상자: 수정 이후 정상 생성

---
Closes: #12 