### PR TITLE
refactor/24 PartyService `createParty` 메서드 로직 변경

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/Enum/RequestGenderOption.java
+++ b/src/main/java/com/wap/app2/gachitayo/Enum/RequestGenderOption.java
@@ -1,0 +1,17 @@
+package com.wap.app2.gachitayo.Enum;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
+public enum RequestGenderOption {
+    MIXED, ONLY;
+
+    @JsonCreator
+    public static RequestGenderOption fromString(String option) {
+        return Arrays.stream(RequestGenderOption.values())
+                .filter(rg -> rg.name().equalsIgnoreCase(option))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -1,12 +1,14 @@
 package com.wap.app2.gachitayo.controller.party;
 
+import com.wap.app2.gachitayo.domain.Member.MemberDetails;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
-import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.service.party.PartyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,8 +18,11 @@ public class PartyController {
     private final PartyService partyService;
 
     @PostMapping
-    public ResponseEntity<PartyCreateResponseDto> createParty(@RequestBody PartyCreateRequestDto requestDto) {
-        return partyService.createParty(requestDto);
+    public ResponseEntity<?> createParty(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody PartyCreateRequestDto requestDto) {
+        if(memberDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Member details cannot be null");
+        }
+        return partyService.createParty(memberDetails.getUsername(), requestDto);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/PartyCreateRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/PartyCreateRequestDto.java
@@ -1,7 +1,7 @@
 package com.wap.app2.gachitayo.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wap.app2.gachitayo.Enum.GenderOption;
+import com.wap.app2.gachitayo.Enum.RequestGenderOption;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import lombok.*;
 
@@ -19,5 +19,5 @@ public class PartyCreateRequestDto {
     @JsonProperty("party_max_person")
     private Integer maxPerson;
     @JsonProperty("party_option")
-    private GenderOption genderOption;
+    private RequestGenderOption genderOption;
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PartyCreateResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PartyCreateResponseDto.java
@@ -9,6 +9,10 @@ import lombok.Builder;
 public record PartyCreateResponseDto(
         @JsonProperty("party_id")
         Long id,
+        @JsonProperty("party_host_name")
+        String hostName,
+        @JsonProperty("party_host_email")
+        String hostEmail,
         @JsonProperty("party_start")
         StopoverDto startLocation,
         @JsonProperty("party_destination")

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -1,0 +1,7 @@
+package com.wap.app2.gachitayo.repository.party;
+
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -2,6 +2,7 @@ package com.wap.app2.gachitayo.service.location;
 
 import com.wap.app2.gachitayo.Enum.LocationType;
 import com.wap.app2.gachitayo.domain.fare.Fare;
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
@@ -33,6 +34,12 @@ public class StopoverService {
         Fare fare = fareService.createDefaultFare(newStopover);
         newStopover.setFare(fare);
         return stopoverRepository.save(newStopover);
+    }
+
+    @Transactional
+    public void addPaymentStatus(Stopover stopover, PaymentStatus paymentStatus) {
+        stopover.getPaymentStatusList().add(paymentStatus);
+        stopoverRepository.save(stopover);
     }
 
     @Transactional

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -1,11 +1,13 @@
 package com.wap.app2.gachitayo.service.location;
 
 import com.wap.app2.gachitayo.Enum.LocationType;
+import com.wap.app2.gachitayo.domain.fare.Fare;
 import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.LocationDto;
 import com.wap.app2.gachitayo.repository.location.StopoverRepository;
+import com.wap.app2.gachitayo.service.fare.FareService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -17,17 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class StopoverService {
     private final StopoverRepository stopoverRepository;
     private final LocationService locationService;
+    private final FareService fareService;
 
     @Transactional
     public Stopover createStopover(LocationDto locationDto, LocationType stopoverType) {
         Location locationEntity = locationService.createOrGetLocation(locationDto);
-        Stopover newStopover = stopoverRepository
-                .save(Stopover.builder()
-                    .location(locationEntity)
-                    .stopoverType(stopoverType)
-                    .build());
+        Stopover newStopover = Stopover.builder()
+                .location(locationEntity)
+                .stopoverType(stopoverType)
+                .build();
+
         locationService.updateStopover(newStopover.getLocation(), newStopover);
-        return newStopover;
+        Fare fare = fareService.createDefaultFare(newStopover);
+        newStopover.setFare(fare);
+        return stopoverRepository.save(newStopover);
     }
 
     @Transactional

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -1,12 +1,25 @@
 package com.wap.app2.gachitayo.service.party;
 
+import com.wap.app2.gachitayo.Enum.PartyMemberRole;
+import com.wap.app2.gachitayo.domain.Member.Member;
+import com.wap.app2.gachitayo.domain.party.Party;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
 import com.wap.app2.gachitayo.repository.party.PartyMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PartyMemberService {
     private final PartyMemberRepository partyMemberRepository;
 
+    @Transactional
+    public PartyMember connectMemberWithParty(Party party, Member member, PartyMemberRole role) {
+        return partyMemberRepository.save(PartyMember.builder()
+                .party(party)
+                .member(member)
+                .memberRole(role)
+                .build());
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -1,0 +1,12 @@
+package com.wap.app2.gachitayo.service.party;
+
+import com.wap.app2.gachitayo.repository.party.PartyMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartyMemberService {
+    private final PartyMemberRepository partyMemberRepository;
+
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -31,7 +31,7 @@ public class PartyService {
     private final StopoverMapper stopoverMapper;
 
     @Transactional
-    public ResponseEntity<PartyCreateResponseDto> createParty(PartyCreateRequestDto requestDto) {
+    public ResponseEntity<PartyCreateResponseDto> createParty(String email, PartyCreateRequestDto requestDto) {
         Stopover startStopover = stopoverService.createStopover(requestDto.getStartLocation().getLocation(), requestDto.getStartLocation().getStopoverType());
         Stopover destStopover = stopoverService.createStopover(requestDto.getDestination().getLocation(), requestDto.getDestination().getStopoverType());
 

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -132,9 +132,11 @@ public class PartyService {
                 .collect(Collectors.toList());
     }
 
-    private PartyCreateResponseDto toResponseDto(Party partyEntity, Stopover startStopover, Stopover destStopover) {
+    private PartyCreateResponseDto toResponseDto(Party partyEntity, Member member, Stopover startStopover, Stopover destStopover) {
         return PartyCreateResponseDto.builder()
                 .id(partyEntity.getId())
+                .hostName(member.getName())
+                .hostEmail(member.getEmail())
                 .startLocation(stopoverMapper.toDto(startStopover))
                 .destination(stopoverMapper.toDto(destStopover))
                 .maxPerson(partyEntity.getMaxPerson())

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -1,5 +1,8 @@
 package com.wap.app2.gachitayo.service.party;
 
+import com.wap.app2.gachitayo.Enum.Gender;
+import com.wap.app2.gachitayo.Enum.GenderOption;
+import com.wap.app2.gachitayo.Enum.RequestGenderOption;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
@@ -119,6 +122,19 @@ public class PartyService {
             );
         }
         return ResponseEntity.ok(responseDtos);
+    }
+
+    private GenderOption matchGenderOption(RequestGenderOption requestGenderOption, Member member) {
+        GenderOption genderOption = (requestGenderOption.equals(RequestGenderOption.ONLY))? null : GenderOption.MIXED;
+        if(genderOption == null) {
+            Gender gender = member.getGender();
+            if(gender.equals(Gender.MALE)) {
+                genderOption = GenderOption.ONLY_MALE;
+            } else {
+                genderOption = GenderOption.ONLY_FEMALE;
+            }
+        }
+        return genderOption;
     }
 
     private ResponseEntity<PartyResponseDto> notFoundPartyResponseEntity(Long partyId) {


### PR DESCRIPTION
## 연관된 이슈

> #21, #24

## 작업 상세

- StopoverService
  -  `createStopover` 변경,  기본 Fare 정보가 연결됨
  - `addPaymentStatus` 추가, PaymentStatus가 연결됨
- 파티 생성 요청 시 RequestGenderOption 사용
  - 동성(ONLY), 혼성(MIXED) 두 개로 구분
- PartyController - `createParty`
  - `@AuthenticationPrincipal` 어노테이션으로 검증된 유저의 정보를 가져옴
  - 가져온 MemberDetails 에서 email 추출
- PartyService - `createParty`
  - 요청 유저를 방장으로
  - `matchGenderOption` - 유저의 성별로 GenderOption 매핑
  - 유저 정보 기반 PartyMember, PaymentStatus 생성 후 연결
- 파티 생성 성공 응답 필드에 방장 정보 필드 추가
  - hostName, hostEmail 필드 추가

## Closes: #24 