### PR TITLE
Refactor/21 파티 생성 로직 변경

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/Enum/RequestGenderOption.java
+++ b/src/main/java/com/wap/app2/gachitayo/Enum/RequestGenderOption.java
@@ -1,0 +1,17 @@
+package com.wap.app2.gachitayo.Enum;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
+public enum RequestGenderOption {
+    MIXED, ONLY;
+
+    @JsonCreator
+    public static RequestGenderOption fromString(String option) {
+        return Arrays.stream(RequestGenderOption.values())
+                .filter(rg -> rg.name().equalsIgnoreCase(option))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -1,12 +1,14 @@
 package com.wap.app2.gachitayo.controller.party;
 
+import com.wap.app2.gachitayo.domain.Member.MemberDetails;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
-import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.service.party.PartyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,8 +18,11 @@ public class PartyController {
     private final PartyService partyService;
 
     @PostMapping
-    public ResponseEntity<PartyCreateResponseDto> createParty(@RequestBody PartyCreateRequestDto requestDto) {
-        return partyService.createParty(requestDto);
+    public ResponseEntity<?> createParty(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody PartyCreateRequestDto requestDto) {
+        if(memberDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Member details cannot be null");
+        }
+        return partyService.createParty(memberDetails.getUsername(), requestDto);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/wap/app2/gachitayo/domain/fare/Fare.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/fare/Fare.java
@@ -2,6 +2,7 @@ package com.wap.app2.gachitayo.domain.fare;
 
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -14,12 +15,14 @@ public class Fare {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     @Builder.Default
-    private Integer baseFigure = 0;
+    private int baseFigure = 0;
 
-    private Integer finalFigure;
+    @NotNull
+    @Builder.Default
+    private int finalFigure = 0;
 
-    @ManyToOne
-    @JoinColumn(name = "stopover_id")
+    @OneToOne(fetch = FetchType.LAZY)
     private Stopover stopover;
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/fare/PaymentStatus.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/fare/PaymentStatus.java
@@ -1,0 +1,33 @@
+package com.wap.app2.gachitayo.domain.fare;
+
+import com.wap.app2.gachitayo.domain.location.Stopover;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "payment_status")
+public class PaymentStatus {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "party_member_id")
+    private PartyMember partyMember;
+
+    @NotNull
+    @ManyToOne
+    @Setter
+    @JoinColumn(name = "stopover_id")
+    private Stopover stopover;
+
+    @NotNull
+    @Builder.Default
+    private boolean isPaid = false;
+}

--- a/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
@@ -4,10 +4,9 @@ import com.wap.app2.gachitayo.Enum.LocationType;
 import com.wap.app2.gachitayo.domain.fare.Fare;
 import com.wap.app2.gachitayo.domain.party.Party;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-import java.util.List;
-import java.util.ArrayList;
 
 @Builder
 @Entity
@@ -27,12 +26,15 @@ public class Stopover {
     @JoinColumn(name = "party_id")
     private Party party;
 
-    @OneToMany(mappedBy = "stopover", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<Fare> fareList = new ArrayList<>();
+    @Setter
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Fare fare;
 
     @Setter
+    @NotNull
     @Enumerated(EnumType.STRING)
-    private LocationType stopoverType;
+    @Builder.Default
+    private LocationType stopoverType = LocationType.STOPOVER;
 
     public boolean update(Location location, LocationType stopoverType) {
         boolean isUpdated = false;

--- a/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
@@ -2,10 +2,14 @@ package com.wap.app2.gachitayo.domain.location;
 
 import com.wap.app2.gachitayo.Enum.LocationType;
 import com.wap.app2.gachitayo.domain.fare.Fare;
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import com.wap.app2.gachitayo.domain.party.Party;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Builder
@@ -29,6 +33,10 @@ public class Stopover {
     @Setter
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private Fare fare;
+
+    @OneToMany(mappedBy = "stopover")
+    @Builder.Default
+    private List<PaymentStatus> paymentStatusList = new ArrayList<>();
 
     @Setter
     @NotNull

--- a/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
@@ -2,12 +2,16 @@ package com.wap.app2.gachitayo.domain.party;
 
 import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import com.wap.app2.gachitayo.domain.Member.Member;
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,6 +30,10 @@ public class PartyMember {
     @ManyToOne
     @JoinColumn(name = "party_id")
     private Party party;
+
+    @OneToMany(mappedBy = "partyMember", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @Builder.Default
+    private List<PaymentStatus> paymentStatusList = new ArrayList<>();
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/PartyCreateRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/PartyCreateRequestDto.java
@@ -1,7 +1,7 @@
 package com.wap.app2.gachitayo.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wap.app2.gachitayo.Enum.GenderOption;
+import com.wap.app2.gachitayo.Enum.RequestGenderOption;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import lombok.*;
 
@@ -19,5 +19,5 @@ public class PartyCreateRequestDto {
     @JsonProperty("party_max_person")
     private Integer maxPerson;
     @JsonProperty("party_option")
-    private GenderOption genderOption;
+    private RequestGenderOption genderOption;
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PartyCreateResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PartyCreateResponseDto.java
@@ -9,6 +9,10 @@ import lombok.Builder;
 public record PartyCreateResponseDto(
         @JsonProperty("party_id")
         Long id,
+        @JsonProperty("party_host_name")
+        String hostName,
+        @JsonProperty("party_host_email")
+        String hostEmail,
         @JsonProperty("party_start")
         StopoverDto startLocation,
         @JsonProperty("party_destination")

--- a/src/main/java/com/wap/app2/gachitayo/repository/fare/FareRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/fare/FareRepository.java
@@ -1,0 +1,7 @@
+package com.wap.app2.gachitayo.repository.fare;
+
+import com.wap.app2.gachitayo.domain.fare.Fare;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FareRepository extends JpaRepository<Fare, Long> {
+}

--- a/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
@@ -1,0 +1,7 @@
+package com.wap.app2.gachitayo.repository.fare;
+
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentStatusRepository extends JpaRepository<PaymentStatus, Long> {
+}

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -1,0 +1,7 @@
+package com.wap.app2.gachitayo.repository.party;
+
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/FareService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/FareService.java
@@ -1,0 +1,24 @@
+package com.wap.app2.gachitayo.service.fare;
+
+import com.wap.app2.gachitayo.domain.fare.Fare;
+import com.wap.app2.gachitayo.domain.location.Stopover;
+import com.wap.app2.gachitayo.repository.fare.FareRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FareService {
+    private final FareRepository fareRepository;
+
+    @Transactional
+    public Fare createDefaultFare(Stopover stopover) {
+        Fare defaultFare = Fare.builder()
+                .stopover(stopover)
+                .baseFigure(0)
+                .finalFigure(0)
+                .build();
+        return fareRepository.save(defaultFare);
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
@@ -1,0 +1,26 @@
+package com.wap.app2.gachitayo.service.fare;
+
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
+import com.wap.app2.gachitayo.domain.location.Stopover;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import com.wap.app2.gachitayo.repository.fare.PaymentStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentStatusService {
+    private final PaymentStatusRepository paymentStatusRepository;
+
+    @Transactional
+    public PaymentStatus connectPartyMemberWithStopover(PartyMember partyMember, Stopover stopover) {
+        PaymentStatus paymentStatus = PaymentStatus.builder()
+                .partyMember(partyMember)
+                .stopover(stopover)
+                .build();
+        return paymentStatusRepository.save(paymentStatus);
+    }
+
+
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -1,0 +1,25 @@
+package com.wap.app2.gachitayo.service.party;
+
+import com.wap.app2.gachitayo.Enum.PartyMemberRole;
+import com.wap.app2.gachitayo.domain.Member.Member;
+import com.wap.app2.gachitayo.domain.party.Party;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import com.wap.app2.gachitayo.repository.party.PartyMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartyMemberService {
+    private final PartyMemberRepository partyMemberRepository;
+
+    @Transactional
+    public PartyMember connectMemberWithParty(Party party, Member member, PartyMemberRole role) {
+        return partyMemberRepository.save(PartyMember.builder()
+                .party(party)
+                .member(member)
+                .memberRole(role)
+                .build());
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -1,14 +1,25 @@
 package com.wap.app2.gachitayo.service.party;
 
+import com.wap.app2.gachitayo.Enum.Gender;
+import com.wap.app2.gachitayo.Enum.GenderOption;
+import com.wap.app2.gachitayo.Enum.PartyMemberRole;
+import com.wap.app2.gachitayo.Enum.RequestGenderOption;
+import com.wap.app2.gachitayo.domain.Member.Member;
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
 import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.dto.response.PartyResponseDto;
+import com.wap.app2.gachitayo.error.exception.ErrorCode;
+import com.wap.app2.gachitayo.error.exception.TagogayoException;
 import com.wap.app2.gachitayo.mapper.StopoverMapper;
 import com.wap.app2.gachitayo.repository.party.PartyRepository;
+import com.wap.app2.gachitayo.service.auth.GoogleAuthService;
+import com.wap.app2.gachitayo.service.fare.PaymentStatusService;
 import com.wap.app2.gachitayo.service.location.StopoverService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,24 +40,39 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final StopoverService stopoverService;
     private final StopoverMapper stopoverMapper;
+    private final GoogleAuthService googleAuthService;
+    private final PartyMemberService partyMemberService;
+    private final PaymentStatusService paymentStatusService;
 
     @Transactional
-    public ResponseEntity<PartyCreateResponseDto> createParty(PartyCreateRequestDto requestDto) {
+    public ResponseEntity<PartyCreateResponseDto> createParty(String email, PartyCreateRequestDto requestDto) {
+        log.info("\n=====파티 생성 시도=====");
+        Member hostMember = googleAuthService.getUserByEmail(email);
+        if (hostMember == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
+
         Stopover startStopover = stopoverService.createStopover(requestDto.getStartLocation().getLocation(), requestDto.getStartLocation().getStopoverType());
         Stopover destStopover = stopoverService.createStopover(requestDto.getDestination().getLocation(), requestDto.getDestination().getStopoverType());
+
+        GenderOption genderOption = matchGenderOption(requestDto.getGenderOption(), hostMember);
 
         Party partyEntity = Party.builder()
                 .stopovers(List.of(startStopover, destStopover))
                 .maxPerson(requestDto.getMaxPerson())
                 .allowRadius(requestDto.getRadius())
-                .genderOption(requestDto.getGenderOption())
+                .genderOption(genderOption)
                 .build();
 
-        stopoverService.setStopoverToParty(startStopover, partyEntity);
-        stopoverService.setStopoverToParty(destStopover, partyEntity);
+        startStopover.setParty(partyEntity);
+        destStopover.setParty(partyEntity);
+
+        PartyMember partyMember = partyMemberService.connectMemberWithParty(partyEntity, hostMember, PartyMemberRole.HOST);
+
+        PaymentStatus paymentStatus = paymentStatusService.connectPartyMemberWithStopover(partyMember, destStopover);
+        stopoverService.addPaymentStatus(destStopover, paymentStatus);
         partyRepository.save(partyEntity);
 
-        return ResponseEntity.ok(toResponseDto(partyEntity, startStopover, destStopover));
+        log.info("\n=====파티 생성 성공=====");
+        return ResponseEntity.ok(toResponseDto(partyEntity, hostMember, startStopover, destStopover));
     }
 
     @Transactional(readOnly = true)
@@ -121,6 +147,19 @@ public class PartyService {
         return ResponseEntity.ok(responseDtos);
     }
 
+    private GenderOption matchGenderOption(RequestGenderOption requestGenderOption, Member member) {
+        GenderOption genderOption = (requestGenderOption.equals(RequestGenderOption.ONLY))? null : GenderOption.MIXED;
+        if(genderOption == null) {
+            Gender gender = member.getGender();
+            if(gender.equals(Gender.MALE)) {
+                genderOption = GenderOption.ONLY_MALE;
+            } else {
+                genderOption = GenderOption.ONLY_FEMALE;
+            }
+        }
+        return genderOption;
+    }
+
     private ResponseEntity<PartyResponseDto> notFoundPartyResponseEntity(Long partyId) {
         log.error("Party not found with id: {}", partyId);
         return ResponseEntity.notFound().build();
@@ -132,9 +171,11 @@ public class PartyService {
                 .collect(Collectors.toList());
     }
 
-    private PartyCreateResponseDto toResponseDto(Party partyEntity, Stopover startStopover, Stopover destStopover) {
+    private PartyCreateResponseDto toResponseDto(Party partyEntity, Member member, Stopover startStopover, Stopover destStopover) {
         return PartyCreateResponseDto.builder()
                 .id(partyEntity.getId())
+                .hostName(member.getName())
+                .hostEmail(member.getEmail())
                 .startLocation(stopoverMapper.toDto(startStopover))
                 .destination(stopoverMapper.toDto(destStopover))
                 .maxPerson(partyEntity.getMaxPerson())


### PR DESCRIPTION
## 연관된 이슈

> #21 #28 

## 작업 상세

- 유저 등록 후 해당 유저와 파티 관계 연결
 - 유저가 해당 경유지에 내릴 것을 의미하는 PaymentStatus
 - 유저가 어디 파티에 속하는지를 의미하는 PartyMember
   - 파티별로 역할 정보 포함
- 경유지 생성 시 기본 Fare 모델 연결
  - 1:1 관계를 위해 기본 Fare 모델 생성
  - 요금 정보 입력 후 해당 경유지에 요금 기입됨
- Controller 단에서 MemberDetails 가져옴
  - 성공적으로 Jwt 생성 시 Authentication 객체 생성 이후 SecurityContextHolder에 저장되므로 `@AuthenticationPrincipal` 어노테이션으로 Authentication 객체 내 MemberDetails 추출 후 email 정보를 서비스 단으로 넘김
- 파티 생성 메서드
  - 유저 이메일로 유저를 찾고 해당 유저를 방장으로 하여금 파티 생성
 
## 테스트 결과

### 요청 헤더
- 서버의 JWT 토큰 (해당 필드 가려져 있고 실제로 요청에 포함되어 있음)

![화면 캡처 2025-04-12 133100](https://github.com/user-attachments/assets/d215f90f-2f30-421b-ae64-30d95057f578)

### 요청 바디

![유저 인증 도입 후 파티 생성 요청 바티](https://github.com/user-attachments/assets/72d58f39-a989-46e3-a041-73c3edc20b55)

### 응답

![유저 인증 도입 후 파티 생성 응답](https://github.com/user-attachments/assets/a662d5b8-a78a-4959-a90f-ebb60bad18a6)

### DB 반영 결과

![유저 인증 도입 후 생성된 DB](https://github.com/user-attachments/assets/4c032bcd-f0cd-4d10-af1c-f40e88fd6a00)

## Closes: #21 