### PR TITLE
Refactor/29 `searchPartiesWithDestinationLocation` 로직 변경

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -36,8 +36,8 @@ public class PartyController {
     }
 
     @PostMapping("/search")
-    public ResponseEntity<?> searchPartyWithLocation(@RequestBody PartySearchRequestDto requestDto) {
-        return partyService.searchPartyWithDestinationLocation(requestDto);
+    public ResponseEntity<?> searchPartiesWithDestinationLocation(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody PartySearchRequestDto requestDto) {
+        return partyService.searchPartiesWithDestinationLocation(memberDetails.getUsername(), requestDto);
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PartyMemberResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PartyMemberResponseDto.java
@@ -1,0 +1,15 @@
+package com.wap.app2.gachitayo.dto.response;
+
+import com.wap.app2.gachitayo.Enum.Gender;
+import com.wap.app2.gachitayo.Enum.PartyMemberRole;
+import lombok.Builder;
+
+@Builder
+public record PartyMemberResponseDto(
+        Long id,
+        String name,
+        String email,
+        Gender gender,
+        PartyMemberRole role
+) {
+}

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PartyResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PartyResponseDto.java
@@ -11,12 +11,16 @@ import java.util.List;
 public record PartyResponseDto(
         @JsonProperty("party_id")
         Long id,
+        @JsonProperty("party_members")
+        List<PartyMemberResponseDto> members,
         @JsonProperty("party_stopovers")
         List<StopoverDto> stopovers,
         @JsonProperty("party_radius")
         Double radius,
-        @JsonProperty("party_max_person")
-        Integer maxPerson,
+        @JsonProperty("party_max_people")
+        Integer maxPeople,
+        @JsonProperty("party_current_people")
+        Integer currentPeople,
         @JsonProperty("party_option")
         GenderOption genderOption
 ) {

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -5,6 +5,10 @@ import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
     boolean existsByPartyAndMember(Party party, Member member);
+
+    List<PartyMember> findAllByParty(Party party);
 }

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -1,7 +1,10 @@
 package com.wap.app2.gachitayo.repository.party;
 
+import com.wap.app2.gachitayo.domain.Member.Member;
+import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
+    boolean existsByPartyAndMember(Party party, Member member);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -4,10 +4,13 @@ import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import com.wap.app2.gachitayo.domain.Member.Member;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
+import com.wap.app2.gachitayo.dto.response.PartyMemberResponseDto;
 import com.wap.app2.gachitayo.repository.party.PartyMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,5 +29,22 @@ public class PartyMemberService {
     @Transactional(readOnly = true)
     public boolean isInParty(Party party, Member member) {
         return partyMemberRepository.existsByPartyAndMember(party, member);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PartyMemberResponseDto> getPartyMemberResponseDtoList(Party party) {
+        List<PartyMember> partyMemberList = partyMemberRepository.findAllByParty(party);
+        return partyMemberList.stream().map(pm ->
+                toResponseDto(pm.getMember(), pm.getMemberRole())).toList();
+    }
+
+    private PartyMemberResponseDto toResponseDto(Member member, PartyMemberRole role) {
+        return PartyMemberResponseDto.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .gender(member.getGender())
+                .role(role)
+                .build();
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -22,4 +22,9 @@ public class PartyMemberService {
                 .memberRole(role)
                 .build());
     }
+
+    @Transactional(readOnly = true)
+    public boolean isInParty(Party party, Member member) {
+        return partyMemberRepository.existsByPartyAndMember(party, member);
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -130,7 +130,7 @@ public class PartyService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseEntity<?> searchPartyWithDestinationLocation(PartySearchRequestDto requestDto) {
+    public ResponseEntity<?> searchPartiesWithDestinationLocation(String email, PartySearchRequestDto requestDto) {
         List<Party> parties = partyRepository.findPartiesWithRadius(requestDto.getLatitude(), requestDto.getLongitude(), requestDto.getRadius());
         List<PartyResponseDto> responseDtos = new ArrayList<>();
         for(Party party : parties) {


### PR DESCRIPTION
## 연관된 이슈

> #29 

## 작업 상세

- 응답 바디에 PartyMember 정보, 현원 포함
- 성별 옵션에 맞지 않는 파티 제외
- 현재 속한 파티 제외 
- 만원인 파티 제외

## 참고 사항

- 테스트 환경을 위해 인가된 유저 한 명 더 필요.
- 따라서 테스트 유예
- 테스트(개발용) 유저 검증 등의 메서드 필요

## 테스트 결과

- 요청 헤더에 서버 발급한 JWT 넣었음

결과
Mr.Hong은 DB에서 임의로 넣은 Mok 유저
![유저 인증 도입 후 파티 검색 결과](https://github.com/user-attachments/assets/fa737088-0ff0-47a4-8c89-07aa4ce9f646)
![유저 인증 도입 후 파티 검색 결과2](https://github.com/user-attachments/assets/0117500a-d279-47ab-a0a1-407673c33b1c)



## Closes: #29 