### PR TITLE
Refactor/34 `addStopoverToParty` 메서드 수정

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -4,6 +4,7 @@ import com.wap.app2.gachitayo.domain.Member.MemberDetails;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
+import com.wap.app2.gachitayo.dto.request.StopoverAddRequestDto;
 import com.wap.app2.gachitayo.service.party.PartyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,8 +32,8 @@ public class PartyController {
     }
 
     @PostMapping("/{id}")
-    public ResponseEntity<?> addStopoverToParty(@PathVariable("id") Long id, @RequestBody StopoverDto stopoverDto) {
-        return partyService.addStopoverToParty(id, stopoverDto);
+    public ResponseEntity<?> addStopoverToParty(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody StopoverAddRequestDto requestDto) {
+        return partyService.addStopoverToParty(memberDetails.getUsername(), id, requestDto);
     }
 
     @PostMapping("/{id}/attend")

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/StopoverAddRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/StopoverAddRequestDto.java
@@ -1,0 +1,16 @@
+package com.wap.app2.gachitayo.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wap.app2.gachitayo.dto.datadto.LocationDto;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StopoverAddRequestDto {
+    @JsonProperty("member_email")
+    private String memberEmail;
+    private LocationDto location;
+}

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     EXCEED_PARTY_MEMBER(HttpStatus.CONFLICT.value(), "PARTY-409-2", "인원이 가득 찬 파티입니다."),
     ALREADY_PARTY_MEMBER(HttpStatus.CONFLICT.value(), "PARTY-409-2", "이미 속한 파티입니다."),
     NOT_MATCH_GENDER_OPTION(HttpStatus.CONFLICT.value(), "PARTY-409-3", "파티 성별 옵션에 맞지 않는 유저입니다."),
+    NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아닙니다."),
+    NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY_403-5", "해당 파티의 방장이 아닙니다."),
 
     INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "Internal Server Error");
 

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -11,4 +11,6 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
     boolean existsByPartyAndMember(Party party, Member member);
 
     List<PartyMember> findAllByParty(Party party);
+
+    PartyMember findByPartyAndMember(Party party, Member member);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -32,6 +32,11 @@ public class PartyMemberService {
     }
 
     @Transactional(readOnly = true)
+    public PartyMember getPartyMemberByPartyAndMember(Party party, Member member) {
+        return partyMemberRepository.findByPartyAndMember(party, member);
+    }
+
+    @Transactional(readOnly = true)
     public List<PartyMemberResponseDto> getPartyMemberResponseDtoList(Party party) {
         List<PartyMember> partyMemberList = partyMemberRepository.findAllByParty(party);
         return partyMemberList.stream().map(pm ->

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -1,21 +1,21 @@
 package com.wap.app2.gachitayo.service.party;
 
-import com.wap.app2.gachitayo.Enum.Gender;
-import com.wap.app2.gachitayo.Enum.GenderOption;
-import com.wap.app2.gachitayo.Enum.PartyMemberRole;
-import com.wap.app2.gachitayo.Enum.RequestGenderOption;
+import com.wap.app2.gachitayo.Enum.*;
 import com.wap.app2.gachitayo.domain.Member.Member;
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
+import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
+import com.wap.app2.gachitayo.dto.request.StopoverAddRequestDto;
 import com.wap.app2.gachitayo.dto.response.PartyCreateResponseDto;
 import com.wap.app2.gachitayo.dto.response.PartyResponseDto;
 import com.wap.app2.gachitayo.error.exception.ErrorCode;
 import com.wap.app2.gachitayo.error.exception.TagogayoException;
+import com.wap.app2.gachitayo.mapper.LocationMapper;
 import com.wap.app2.gachitayo.mapper.StopoverMapper;
 import com.wap.app2.gachitayo.repository.party.PartyRepository;
 import com.wap.app2.gachitayo.service.auth.GoogleAuthService;
@@ -44,6 +44,7 @@ public class PartyService {
     private final GoogleAuthService googleAuthService;
     private final PartyMemberService partyMemberService;
     private final PaymentStatusService paymentStatusService;
+    private final LocationMapper locationMapper;
 
     @Transactional
     public ResponseEntity<PartyCreateResponseDto> createParty(String email, PartyCreateRequestDto requestDto) {
@@ -114,23 +115,39 @@ public class PartyService {
     }
 
     @Transactional
-    public ResponseEntity<?> addStopoverToParty(Long partyId, StopoverDto requestDto) {
-        Party partyEntity = partyRepository.findById(partyId).orElse(null);
-        if(partyEntity == null) {
-            return notFoundPartyResponseEntity(partyId);
-        }
+    public ResponseEntity<?> addStopoverToParty(String email, Long partyId, StopoverAddRequestDto requestDto) {
+        log.info("\n=====파티 내 하차 지점 추가 시도=====");
+        Party partyEntity = partyRepository.findById(partyId).orElseThrow(() -> new TagogayoException(ErrorCode.PARTY_NOT_FOUND));
 
-        Stopover stopoverEntity = stopoverService.createStopover(requestDto.getLocation(), requestDto.getStopoverType());
+        // HOST 검증
+        Member hostMember = googleAuthService.getUserByEmail(email);
+        if (hostMember == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
+        PartyMember partyHost = partyEntity.getPartyMemberList().stream()
+                .filter(pm -> hostMember.getId().equals(pm.getMember().getId())).findFirst()
+                .orElseThrow(() -> new TagogayoException(ErrorCode.NOT_IN_PARTY));
+        if(!partyHost.getMemberRole().equals(PartyMemberRole.HOST)) throw new TagogayoException(ErrorCode.NOT_HOST);
 
-        boolean isExist = partyEntity.getStopovers().stream()
-                .anyMatch(stopover -> stopover.getLocation().equals(stopoverEntity.getLocation()));
+        // 연결 시킬 유저 검증
+        Member participant = googleAuthService.getUserByEmail(requestDto.getMemberEmail());
+        if(participant == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
+        if(!partyMemberService.isInParty(partyEntity, participant)) throw new TagogayoException(ErrorCode.NOT_IN_PARTY);
 
-        if(!isExist) {
-            stopoverService.setStopoverToParty(stopoverEntity, partyEntity);
+        Stopover stopoverEntity = partyEntity.getStopovers().stream()
+                .filter(s -> existStopoverWithLocation(s, locationMapper.toEntity(requestDto.getLocation()))).findFirst().orElse(null);
+
+        if(stopoverEntity == null) {
+            log.info("새로운 하차 지점 생성");
+            stopoverEntity = stopoverService.createStopover(requestDto.getLocation(), LocationType.STOPOVER);
+            stopoverEntity.setParty(partyEntity);
             partyEntity.getStopovers().add(stopoverEntity);
-            partyRepository.save(partyEntity);
         }
 
+        PartyMember partyMember = partyMemberService.getPartyMemberByPartyAndMember(partyEntity, participant);
+        PaymentStatus paymentStatus = paymentStatusService.connectPartyMemberWithStopover(partyMember, stopoverEntity);
+        stopoverService.addPaymentStatus(stopoverEntity, paymentStatus);
+        partyRepository.save(partyEntity);
+
+        log.info("\n=====하차 지점 추가 성공=====");
         return ResponseEntity.noContent().build();
     }
 
@@ -198,6 +215,12 @@ public class PartyService {
             }
         }
         return genderOption;
+    }
+
+    private boolean existStopoverWithLocation(Stopover stopover, Location location) {
+        return stopover.getLocation().getAddress().equalsIgnoreCase(location.getAddress())
+                && stopover.getLocation().getLatitude() == location.getLatitude()
+                && stopover.getLocation().getLongitude() == location.getLongitude();
     }
 
     private ResponseEntity<PartyResponseDto> notFoundPartyResponseEntity(Long partyId) {


### PR DESCRIPTION
## 연관된 이슈

> #34 

## 작업 상세

- 하차 지점 설정은 방장만 가능하므로 현재 요청 유저가 방장인지 검증
- 요청 본문에 하차할 유저의 이메일로 유저 검증
- 검증 이후 파티 내 존재하는 하차 지점인지 검사
  - 없을 경우 새로 만듦
- 하차하는 유저의 PaymentStatus 추가

## 테스트 

- 헤더에 JWT 토큰 포함 
- 현재 유저는 방장임

![유저 인증 도입 후 하차 지점 추가 요청 결과](https://github.com/user-attachments/assets/d87a4a13-4153-4f05-a75d-754e51cc112f)

- DB 반영 결과

![하차 지점 추가 DB 결과](https://github.com/user-attachments/assets/6a6a69c1-61b4-4cfd-a049-5b25744e4893)

### 응답 코드

200 응답, 응답 본문에 정보 반영으로 변경할 예정

## Closes: #34 