### PR TITLE
Refactor/36 updatestopover

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -1,10 +1,10 @@
 package com.wap.app2.gachitayo.controller.party;
 
 import com.wap.app2.gachitayo.domain.Member.MemberDetails;
-import com.wap.app2.gachitayo.dto.datadto.StopoverDto;
 import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
 import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
 import com.wap.app2.gachitayo.dto.request.StopoverAddRequestDto;
+import com.wap.app2.gachitayo.dto.request.StopoverUpdateDto;
 import com.wap.app2.gachitayo.service.party.PartyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,7 +47,7 @@ public class PartyController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<?> updateStopover(@PathVariable("id") Long id, @RequestBody StopoverDto stopoverDto) {
-        return partyService.updateStopover(id, stopoverDto);
+    public ResponseEntity<?> updateStopover(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody StopoverUpdateDto updateDto) {
+        return partyService.updateStopover(memberDetails.getUsername(), id, updateDto);
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/StopoverUpdateDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/StopoverUpdateDto.java
@@ -1,0 +1,27 @@
+package com.wap.app2.gachitayo.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wap.app2.gachitayo.Enum.LocationType;
+import com.wap.app2.gachitayo.dto.datadto.LocationDto;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StopoverUpdateDto {
+    @NotNull
+    @JsonProperty("stopover_id")
+    private Long stopoverId;
+    @Email
+    @JsonProperty("member_email")
+    private String memberEmail;
+    private LocationDto location;
+    @JsonProperty("stopover_type")
+    private LocationType stopoverType;
+}

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아닙니다."),
     NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY_403-5", "해당 파티의 방장이 아닙니다."),
 
+    //Stopover
+    STOPOVER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "STOPOVER-404-1", "존재하지 않는 경유지입니다."),
+
     INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "Internal Server Error");
 
     private final int status;

--- a/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
@@ -1,7 +1,10 @@
 package com.wap.app2.gachitayo.repository.fare;
 
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
+import com.wap.app2.gachitayo.domain.party.PartyMember;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentStatusRepository extends JpaRepository<PaymentStatus, Long> {
+    PaymentStatus findByPartyMember(@NotNull PartyMember partyMember);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
@@ -22,5 +22,13 @@ public class PaymentStatusService {
         return paymentStatusRepository.save(paymentStatus);
     }
 
-
+    @Transactional
+    public boolean updateStopover(PartyMember partyMember, Stopover stopover) {
+        PaymentStatus existingPaymentStatus = paymentStatusRepository.findByPartyMember(partyMember);
+        if(existingPaymentStatus == null) return false;
+        if(existingPaymentStatus.getStopover().equals(stopover)) return false;
+        existingPaymentStatus.setStopover(stopover);
+        paymentStatusRepository.save(existingPaymentStatus);
+        return true;
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -5,12 +5,10 @@ import com.wap.app2.gachitayo.domain.fare.Fare;
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
-import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.LocationDto;
 import com.wap.app2.gachitayo.repository.location.StopoverRepository;
 import com.wap.app2.gachitayo.service.fare.FareService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,19 +41,13 @@ public class StopoverService {
     }
 
     @Transactional
-    public void setStopoverToParty(Stopover stopover, Party party) {
-        stopover.setParty(party);
-        stopoverRepository.save(stopover);
-    }
-
-    @Transactional
-    public ResponseEntity<?> updateStopover(Stopover stopover, LocationDto locationDto, LocationType stopoverType) {
+    public boolean updateStopover(Stopover stopover, LocationDto locationDto, LocationType stopoverType) {
         Location locationEntity = (locationDto != null) ? locationService.createOrGetLocation(locationDto) : null;
         if(!stopover.update(locationEntity, stopoverType)) {
-            return ResponseEntity.ok().body("no changed");
+            return false;
         }
 
         stopoverRepository.save(stopover);
-        return ResponseEntity.ok().body("updated stopover");
+        return true;
     }
 }


### PR DESCRIPTION
## 연관된 이슈

> #36 

## 작업 상세

- 방장 검증 추가
- 하차 지점에 다른 유저 추가 시 유저 검증 추가
- Stopover에 대한 Create, Add, Update Dto 분리
- PaymentStatus 업데이트

## 테스트

- 헤더에 JWT 포함
- 요청 유저는 방장임

- Stopover 타입 변경

![업데이트 요청 결과222](https://github.com/user-attachments/assets/d2490c97-623a-4181-bdfe-f793328ce376)

- 하차 지점에 해당 유저로 변경

![유저 경유지 업데이트 결과222](https://github.com/user-attachments/assets/c1c0cb9a-47b6-4633-a35a-60b6416e40b7)

- DB 반영 결과

![업데이트 DB 반영 결과](https://github.com/user-attachments/assets/651391a5-dfa9-4ac6-bff9-03cba9e31ca7)

## Closes: #36 
