### PR TITLE
Feature/58 id token null check

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/member/MemberController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/member/MemberController.java
@@ -1,15 +1,14 @@
 package com.wap.app2.gachitayo.controller.member;
 
 import com.wap.app2.gachitayo.domain.Member.MemberDetails;
+import com.wap.app2.gachitayo.dto.request.EditMemberRequest;
 import com.wap.app2.gachitayo.dto.response.MemberProfileResponseDto;
 import com.wap.app2.gachitayo.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/profile")
 @RequiredArgsConstructor
@@ -23,5 +22,10 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<MemberProfileResponseDto> getProfile(@AuthenticationPrincipal MemberDetails memberDetails) {
         return memberService.getMemberProfile(memberDetails.getUsername());
+    }
+
+    @PatchMapping
+    public ResponseEntity<MemberProfileResponseDto> changeName(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody EditMemberRequest request) {
+        return memberService.changeName(memberDetails.getUsername(), request);
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/Member/Member.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/Member/Member.java
@@ -4,10 +4,7 @@ import com.wap.app2.gachitayo.Enum.Gender;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -16,6 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/EditMemberRequest.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/EditMemberRequest.java
@@ -1,0 +1,6 @@
+package com.wap.app2.gachitayo.dto.request;
+
+public record EditMemberRequest(
+        String name
+) {
+}

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ALREADY_SIGNUP(400, "MEMBER-400-1", "이미 회원가입된 회원입니다."),
     INVALID_REQUEST(400, "MEMBER-400-2", "잘못된 요청입니다."),
     NOT_MATCH_EMAIL(400, "MEMBER-400-3", "이메일 주소가 잘못 되었습니다."),
+    INVALID_TOKEN(400, "MEMBER-400-4", "idToken 검증에 실패하였습니다."),
     MEMBER_NOT_LOGIN(403, "USER-403-1", "로그인되어 있지 않습니다."),
     MEMBER_NOT_FOUND(404, "MEMBER-404-1", "회원을 조회할 수 없습니다."),
 

--- a/src/main/java/com/wap/app2/gachitayo/service/auth/GoogleAuthService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/auth/GoogleAuthService.java
@@ -118,6 +118,8 @@ public class GoogleAuthService {
         try {
             GoogleIdToken idToken = verifier.verify(_idToken);
 
+            if (idToken == null) throw new TagogayoException(ErrorCode.INVALID_TOKEN);
+
             GoogleIdToken.Payload payload = idToken.getPayload();
             return payload.getEmail();
 

--- a/src/main/java/com/wap/app2/gachitayo/service/member/MemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/member/MemberService.java
@@ -2,10 +2,12 @@ package com.wap.app2.gachitayo.service.member;
 
 import com.wap.app2.gachitayo.domain.Member.Member;
 import com.wap.app2.gachitayo.domain.Member.MemberDetails;
+import com.wap.app2.gachitayo.dto.request.EditMemberRequest;
 import com.wap.app2.gachitayo.dto.response.MemberProfileResponseDto;
 import com.wap.app2.gachitayo.error.exception.ErrorCode;
 import com.wap.app2.gachitayo.error.exception.TagogayoException;
 import com.wap.app2.gachitayo.repository.auth.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,28 @@ public class MemberService {
         if (member == null) {
             throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
         }
+
+        MemberProfileResponseDto dto = new MemberProfileResponseDto(
+                member.getName(),
+                member.getPhone(),
+                member.getAge(),
+                member.getGender(),
+                member.getProfileImageUrl(),
+                member.getEmail()
+        );
+
+        return ResponseEntity.ok(dto);
+    }
+
+    @Transactional
+    public ResponseEntity<MemberProfileResponseDto> changeName(String email, EditMemberRequest editMemberRequest) {
+        Member member = this.getUserByEmail(email);
+
+        if (member == null) {
+            throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        member.setName(editMemberRequest.name());
 
         MemberProfileResponseDto dto = new MemberProfileResponseDto(
                 member.getName(),


### PR DESCRIPTION
## #️⃣연관된 이슈 
#56 

## 📝작업 내용

idToken의 null 체킹 로직 추가


## 논의하고 싶은 부분
GoogleIdTokenVerifier의 에러가 존재하지않고 검증 실패시 idToken이 null 반환 밖에안되는거같은데
try-catch를 삭제해야할까요?

## Close-Issue: #58 