### PR TITLE
Feature/61 refresh token with redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'com.google.api-client:google-api-client:2.7.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/wap/app2/gachitayo/config/RedisConfig.java
+++ b/src/main/java/com/wap/app2/gachitayo/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.wap.app2.gachitayo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.user}")
+    private String username;
+
+    @Value("${spring.redis.pw}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setUsername(username);
+        config.setPassword(RedisPassword.of(password));
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/wap/app2/gachitayo/jwt/JwtTokenProvider.java
@@ -17,7 +17,7 @@ import java.util.Date;
 @Component
 public class JwtTokenProvider {
     private final SecretKey secretKey;
-    private final Long AccessTokenExpiredMs = 999* 1000L * 60L * 60L; // 1시간
+    private final Long AccessTokenExpiredMs = 1 * 1000L * 60L * 60L; // 1시간
     private final Long RefreshTokenExpiredMs = 7 * 24 * 1000L * 60L * 60L; // 1주일
 
     public JwtTokenProvider(@Value("${spring.jwt.secret}") String secret) {

--- a/src/main/java/com/wap/app2/gachitayo/service/auth/GoogleAuthService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/auth/GoogleAuthService.java
@@ -17,11 +17,13 @@ import com.wap.app2.gachitayo.repository.auth.MemberRepository;
 import com.wap.app2.gachitayo.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 import java.util.Collections;
 
 @Service
@@ -33,6 +35,7 @@ public class GoogleAuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final MemberService memberService;
+    private final StringRedisTemplate redisTemplate;
 
     public ResponseEntity<TokenResponseDto> userLogin(LoginRequestDto requestDto) {
         String idToken = requestDto.idToken();
@@ -43,13 +46,7 @@ public class GoogleAuthService {
 
         if (member == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
 
-        String accessToken = jwtTokenProvider.createAccessToken(email);
-        String refreshToken = jwtTokenProvider.createRefreshToken();
-
-        Token token = new Token(
-                accessToken,
-                refreshToken
-        );
+        Token token = generateToken(email);
 
         return ResponseEntity.ok(TokenResponseDto.from(token));
     }
@@ -79,33 +76,45 @@ public class GoogleAuthService {
 
         memberRepository.save(member);
 
-        String accessToken = jwtTokenProvider.createAccessToken(email);
-        String refreshToken = jwtTokenProvider.createRefreshToken();
-
-        Token token = new Token(
-                accessToken,
-                refreshToken
-        );
+        Token token = generateToken(email);
 
         return ResponseEntity.ok(TokenResponseDto.from(token));
     }
 
     public ResponseEntity<TokenResponseDto> reissueToken(ReissueReqeuestDto requestDto) {
-        //db에서 해당 refreshToken 가진사람 가져오기
-        //repository.get~~();
-        //레디스 사용시 만료 되었는지 확인할 필요없음
+        //RTR 방식 도입으로 토큰 탈취에 대한 보안강화 예정
+        String rfToken = requestDto.refreshToken();
 
-        boolean isValid = jwtTokenProvider.isValid(requestDto.refreshToken());
+        boolean isValid = jwtTokenProvider.isValid(rfToken);
 
-        //Redis 사용시 불필요함
-        if (!isValid) return ResponseEntity.internalServerError().build();
+        if (!isValid) {
+            //rf expired
+            throw new TagogayoException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
 
-        //유저를 디비에서 유저를 가져오는게 아니라 모름...
-        Token token = new Token(
-            jwtTokenProvider.createAccessToken("test@pukyong.ac.kr"),
-            jwtTokenProvider.createRefreshToken()
-        );
+        String email = redisTemplate.opsForValue().get(rfToken);
+
+        if (email == null) {
+            //rf expired, 토큰 검증 완료되었는데 db 케이스는 존재할 수 없음.
+            throw new TagogayoException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        Token token = generateToken(email);
+
         return ResponseEntity.ok(TokenResponseDto.from(token));
+    }
+
+    public Token generateToken(String email) {
+        String accessToken = jwtTokenProvider.createAccessToken(email);
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        //TTL 일주일로 레디스 저장
+        redisTemplate.opsForValue().set(refreshToken, email, Duration.ofDays(7));
+
+        return new Token(
+                accessToken,
+                refreshToken
+        );
     }
 
     public String getUserEmail(String _idToken, String _accessToken) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#61 

## 📝작업 내용

- 레디스 연동
- 토큰발급시 redis에 리프레시 토큰과 email 저장
- 리프레시토큰을 이용한 액세스 토큰 재발행

## 중점적으로 리뷰받고 싶은 부분
        if (!isValid) {
            //rf expired
            throw new TagogayoException(ErrorCode.REFRESH_TOKEN_EXPIRED);
        }

        String email = redisTemplate.opsForValue().get(rfToken);

        if (email == null) {
            //rf expired, 토큰 검증 완료되었는데 db 케이스는 존재할 수 없음.
            throw new TagogayoException(ErrorCode.REFRESH_TOKEN_EXPIRED);
        }

위 케이스는 두개 중 하나만 검증해도 되긴합니다. 두개 케이스 모두 확인하는게 좋을까요?

## Close-Issue: #61 