### PR TITLE
Feature/81 최종 결산자 등록

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/Enum/AdditionalRole.java
+++ b/src/main/java/com/wap/app2/gachitayo/Enum/AdditionalRole.java
@@ -1,0 +1,17 @@
+package com.wap.app2.gachitayo.Enum;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
+public enum AdditionalRole {
+    NONE, BOOKKEEPER;
+
+    @JsonCreator
+    public static PartyMemberRole fromString(String additionalRole) {
+        return Arrays.stream(PartyMemberRole.values())
+                .filter(r -> r.name().equalsIgnoreCase(additionalRole))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -41,4 +41,9 @@ public class PartyController {
     public ResponseEntity<?> updateStopover(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody StopoverUpdateDto updateDto) {
         return partyFacade.updateStopover(memberDetails.getUsername(), id, updateDto);
     }
+
+    @PatchMapping("/{id}/bookkeeper")
+    public ResponseEntity<?> electBookkeeper(@RequestParam("partyMemberId") Long partyMemberId, @PathVariable("id") Long partyId, @AuthenticationPrincipal MemberDetails memberDetails) {
+        return partyFacade.electBookkeeper(partyId, memberDetails.getUsername(), partyMemberId);
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -42,8 +42,8 @@ public class PartyController {
         return partyFacade.updateStopover(memberDetails.getUsername(), id, updateDto);
     }
 
-    @PatchMapping("/{id}/bookkeeper")
-    public ResponseEntity<?> electBookkeeper(@RequestParam("partyMemberId") Long partyMemberId, @PathVariable("id") Long partyId, @AuthenticationPrincipal MemberDetails memberDetails) {
+    @PatchMapping("/{partyId}/member/{partyMemberId}/bookkeeper")
+    public ResponseEntity<?> electBookkeeper(@PathVariable("partyId") Long partyId, @PathVariable("partyMemberId") Long partyMemberId, @AuthenticationPrincipal MemberDetails memberDetails) {
         return partyFacade.electBookkeeper(partyId, memberDetails.getUsername(), partyMemberId);
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
@@ -1,5 +1,6 @@
 package com.wap.app2.gachitayo.domain.party;
 
+import com.wap.app2.gachitayo.Enum.AdditionalRole;
 import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import com.wap.app2.gachitayo.domain.member.Member;
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
@@ -37,4 +38,10 @@ public class PartyMember {
     @Setter
     @Builder.Default
     private PartyMemberRole memberRole = PartyMemberRole.MEMBER;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Setter
+    @Builder.Default
+    private AdditionalRole additionalRole = AdditionalRole.NONE;
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/party/PartyMember.java
@@ -5,10 +5,7 @@ import com.wap.app2.gachitayo.domain.member.Member;
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +34,7 @@ public class PartyMember {
 
     @NotNull
     @Enumerated(EnumType.STRING)
+    @Setter
     @Builder.Default
     private PartyMemberRole memberRole = PartyMemberRole.MEMBER;
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PartyMemberResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PartyMemberResponseDto.java
@@ -1,15 +1,21 @@
 package com.wap.app2.gachitayo.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wap.app2.gachitayo.Enum.AdditionalRole;
 import com.wap.app2.gachitayo.Enum.Gender;
 import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import lombok.Builder;
 
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record PartyMemberResponseDto(
         Long id,
         String name,
         String email,
         Gender gender,
-        PartyMemberRole role
+        PartyMemberRole role,
+        @JsonProperty("additional_role")
+        AdditionalRole additionalRole
 ) {
 }

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     ALREADY_PARTY_MEMBER(HttpStatus.CONFLICT.value(), "PARTY-409-2", "이미 속한 파티입니다."),
     NOT_MATCH_GENDER_OPTION(HttpStatus.CONFLICT.value(), "PARTY-409-3", "파티 성별 옵션에 맞지 않는 유저입니다."),
     NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아닙니다."),
-    NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY_403-5", "해당 파티의 방장이 아닙니다."),
+    NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY-403-5", "해당 파티의 방장이 아닙니다."),
+    PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "PARTY-404-6", "해당 파티의 유저가 아니거나 찾을 수 없습니다."),
 
     //Stopover
     STOPOVER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "STOPOVER-404-1", "존재하지 않는 경유지입니다."),

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
@@ -111,6 +111,7 @@ public class PartyFacade {
                                         .email(pm.getMember().getEmail())
                                         .gender(pm.getMember().getGender())
                                         .role(pm.getMemberRole())
+                                        .additionalRole(pm.getAdditionalRole())
                                         .build()).toList()
         ));
     }
@@ -220,11 +221,20 @@ public class PartyFacade {
 
         PartyMember targetPartyMember = partyMemberService.getPartyMemberById(targetPartyMemberId);
 
-        party.getPartyMemberList().stream()
-                .filter(pm -> pm.getMemberRole().equals(PartyMemberRole.BOOKKEEPER))
-                .forEach(pm -> partyMemberService.changePartyMemberRole(pm, PartyMemberRole.MEMBER));
+        for(PartyMember pm : party.getPartyMemberList()) {
+            if (pm.getMemberRole().equals(PartyMemberRole.HOST) && pm.getAdditionalRole().equals(AdditionalRole.BOOKKEEPER)) {
+                partyMemberService.changeAdditionalRole(pm, AdditionalRole.NONE);
+            }
+            else if (pm.getMemberRole().equals(PartyMemberRole.BOOKKEEPER)) {
+                partyMemberService.changePartyMemberRole(pm, PartyMemberRole.MEMBER);
+            }
+        }
 
-        partyMemberService.changePartyMemberRole(targetPartyMember, PartyMemberRole.BOOKKEEPER);
+        if(targetPartyMember.getMemberRole().equals(PartyMemberRole.HOST)) {
+            partyMemberService.changeAdditionalRole(targetPartyMember, AdditionalRole.BOOKKEEPER);
+        } else if (targetPartyMember.getMemberRole().equals(PartyMemberRole.MEMBER)) {
+            partyMemberService.changePartyMemberRole(targetPartyMember, PartyMemberRole.BOOKKEEPER);
+        }
 
         return ResponseEntity.ok(party.getPartyMemberList().stream().map(this::toPartyMemberResponseDto).toList());
     }
@@ -262,6 +272,7 @@ public class PartyFacade {
                 .email(partyMember.getMember().getEmail())
                 .gender(partyMember.getMember().getGender())
                 .role(partyMember.getMemberRole())
+                .additionalRole(partyMember.getAdditionalRole())
                 .build();
     }
 

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -5,6 +5,8 @@ import com.wap.app2.gachitayo.domain.member.Member;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import com.wap.app2.gachitayo.dto.response.PartyMemberResponseDto;
+import com.wap.app2.gachitayo.error.exception.ErrorCode;
+import com.wap.app2.gachitayo.error.exception.TagogayoException;
 import com.wap.app2.gachitayo.repository.party.PartyMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -44,6 +46,11 @@ public class PartyMemberService {
         List<PartyMember> partyMemberList = partyMemberRepository.findAllByParty(party);
         return partyMemberList.stream().map(pm ->
                 toResponseDto(pm.getMember(), pm.getMemberRole())).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PartyMember getPartyMemberById(Long id) {
+        return partyMemberRepository.findById(id).orElseThrow(() -> new TagogayoException(ErrorCode.PARTY_MEMBER_NOT_FOUND));
     }
 
     private PartyMemberResponseDto toResponseDto(Member member, PartyMemberRole role) {

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -53,6 +53,12 @@ public class PartyMemberService {
         return partyMemberRepository.findById(id).orElseThrow(() -> new TagogayoException(ErrorCode.PARTY_MEMBER_NOT_FOUND));
     }
 
+    @Transactional
+    public void changePartyMemberRole(PartyMember partyMember, PartyMemberRole role) {
+        partyMember.setMemberRole(role);
+        partyMemberRepository.save(partyMember);
+    }
+
     private PartyMemberResponseDto toResponseDto(Member member, PartyMemberRole role) {
         return PartyMemberResponseDto.builder()
                 .id(member.getId())

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -1,5 +1,6 @@
 package com.wap.app2.gachitayo.service.party;
 
+import com.wap.app2.gachitayo.Enum.AdditionalRole;
 import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import com.wap.app2.gachitayo.domain.member.Member;
 import com.wap.app2.gachitayo.domain.party.Party;
@@ -56,6 +57,12 @@ public class PartyMemberService {
     @Transactional
     public void changePartyMemberRole(PartyMember partyMember, PartyMemberRole role) {
         partyMember.setMemberRole(role);
+        partyMemberRepository.save(partyMember);
+    }
+
+    @Transactional
+    public void changeAdditionalRole(PartyMember partyMember, AdditionalRole role) {
+        partyMember.setAdditionalRole(role);
         partyMemberRepository.save(partyMember);
     }
 


### PR DESCRIPTION
## 연관된 이슈

> #81 

## 작업 상세

- `PATCH`, `/api/party/{partyId}/member/{partyMemberId}/bookkeeper` 엔드포인트
  - `partyId`에 해당하는 파티의 최종 결산자는 `partyMemberId`에 해당하는 유저가 됨을 의미
- 파티 내 BOOKKEEPER는 한 명만 존재한다고 가정
  - 최종 결산자 결정 전 이전의 BOOKKEEPER인 유저를 모두 MEMBER로 변경 후 한 명만 최종 결산자로 지정
  - 방장의 경우 additional_role에 최종 결산자 여부가 반영

## 테스트

- 등록 전 상태

![최종 결산자 등록 전 방장 반영버전](https://github.com/user-attachments/assets/518b698a-e3dc-43d8-bb01-32ebf48996f7)

- 등록 후 결과

![최종 결산자 반영 요청-응답 방장 반영 버전](https://github.com/user-attachments/assets/1d8b286e-96b5-4ecd-b715-86b62853d1c9)

- 반영 DB 내용

![최종 결산자 반영 방장도 가능 버전](https://github.com/user-attachments/assets/5cff5044-c676-4f13-865b-c8404e611868)

- 의도치 않게 결산자가 2 명인 경우

![최종 결산자 비정상적인 상황](https://github.com/user-attachments/assets/5513d474-2dbd-4490-8d98-dbabd89b9a9f)

- 정상 반영 결과

![최종 결산자 비정상 상황 정상 응답](https://github.com/user-attachments/assets/954e3ef3-5126-4742-b540-ed7f238a10af)

- 반영 DB 내용

![최종 결산자 비정상 상황 성공적인 DB 반영](https://github.com/user-attachments/assets/dcfc72bd-284a-4ac6-98cb-1bb18ec2f496)

## Closes: #81 