### PR TITLE
Feature/53 금액 입력 반영

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -1,15 +1,14 @@
 package com.wap.app2.gachitayo.controller.party;
 
 import com.wap.app2.gachitayo.domain.member.MemberDetails;
-import com.wap.app2.gachitayo.dto.request.PartyCreateRequestDto;
-import com.wap.app2.gachitayo.dto.request.PartySearchRequestDto;
-import com.wap.app2.gachitayo.dto.request.StopoverAddRequestDto;
-import com.wap.app2.gachitayo.dto.request.StopoverUpdateDto;
+import com.wap.app2.gachitayo.dto.request.*;
 import com.wap.app2.gachitayo.service.party.PartyFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/party")
@@ -45,5 +44,10 @@ public class PartyController {
     @PatchMapping("/{partyId}/member/{partyMemberId}/bookkeeper")
     public ResponseEntity<?> electBookkeeper(@PathVariable("partyId") Long partyId, @PathVariable("partyMemberId") Long partyMemberId, @AuthenticationPrincipal MemberDetails memberDetails) {
         return partyFacade.electBookkeeper(partyId, memberDetails.getUsername(), partyMemberId);
+    }
+
+    @PostMapping("/{id}/fare")
+    public ResponseEntity<?> reflectCalculatedFare(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody List<FareRequestDto> requestDtoList) {
+        return partyFacade.reflectCalculatedFare(id, memberDetails.getUsername(), requestDtoList);
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/fare/Fare.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/fare/Fare.java
@@ -3,9 +3,7 @@ package com.wap.app2.gachitayo.domain.fare;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Builder
@@ -16,12 +14,10 @@ public class Fare {
     private Long id;
 
     @NotNull
+    @Getter
+    @Setter
     @Builder.Default
     private int baseFigure = 0;
-
-    @NotNull
-    @Builder.Default
-    private int finalFigure = 0;
 
     @OneToOne(fetch = FetchType.LAZY)
     private Stopover stopover;

--- a/src/main/java/com/wap/app2/gachitayo/domain/fare/PaymentStatus.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/fare/PaymentStatus.java
@@ -28,6 +28,12 @@ public class PaymentStatus {
     private Stopover stopover;
 
     @NotNull
+    @Setter
+    @Builder.Default
+    private int finalFigure = 0;
+
+    @NotNull
+    @Setter
     @Builder.Default
     private boolean isPaid = false;
 }

--- a/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/location/Stopover.java
@@ -7,6 +7,7 @@ import com.wap.app2.gachitayo.domain.party.Party;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,7 @@ public class Stopover {
     private Fare fare;
 
     @OneToMany(mappedBy = "stopover", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 4)
     @Builder.Default
     private List<PaymentStatus> paymentStatusList = new ArrayList<>();
 

--- a/src/main/java/com/wap/app2/gachitayo/domain/party/Party.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/party/Party.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,10 +39,12 @@ public class Party {
     private GenderOption genderOption = GenderOption.MIXED;
 
     @OneToMany(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 5)
     @Builder.Default
     private List<Stopover> stopovers = new ArrayList<>();
 
     @OneToMany(mappedBy = "party", cascade = CascadeType.ALL)
+    @BatchSize(size = 4)
     @Builder.Default
     private List<PartyMember> partyMemberList = new ArrayList<>();
 

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/FareRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/FareRequestDto.java
@@ -1,0 +1,15 @@
+package com.wap.app2.gachitayo.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FareRequestDto {
+    @JsonProperty("stopover_id")
+    private Long stopoverId;
+    private Integer fare;
+}

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/FinalPaymentStatusResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/FinalPaymentStatusResponseDto.java
@@ -1,0 +1,13 @@
+package com.wap.app2.gachitayo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record FinalPaymentStatusResponseDto(
+        @JsonProperty("party_member_info")
+        PartyMemberResponseDto partyMemberInfo,
+        @JsonProperty("payment_info")
+        PaymentStatusResponseDto paymentStatus
+) {
+}

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/PaymentStatusResponseDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/PaymentStatusResponseDto.java
@@ -1,0 +1,17 @@
+package com.wap.app2.gachitayo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record PaymentStatusResponseDto(
+        @JsonProperty("stopover_id")
+        Long stopoverId,
+        @JsonProperty("base_fare")
+        Integer baseFare,
+        @JsonProperty("final_fare")
+        Integer finalFare,
+        @JsonProperty("is_paid")
+        Boolean isPaid
+) {
+}

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아닙니다."),
     NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY-403-5", "해당 파티의 방장이 아닙니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "PARTY-404-6", "해당 파티의 유저가 아니거나 찾을 수 없습니다."),
+    NOT_BOOKKEEPER(HttpStatus.FORBIDDEN.value(), "PARTY-403-7", "해당 파티의 최종 결산자가 아닙니다."),
 
     //Stopover
     STOPOVER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "STOPOVER-404-1", "존재하지 않는 경유지입니다."),

--- a/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/fare/PaymentStatusRepository.java
@@ -1,10 +1,22 @@
 package com.wap.app2.gachitayo.repository.fare;
 
 import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
+import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.PartyMember;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface PaymentStatusRepository extends JpaRepository<PaymentStatus, Long> {
     PaymentStatus findByPartyMember(@NotNull PartyMember partyMember);
+
+    @Query("""
+        SELECT ps FROM PaymentStatus ps
+        JOIN FETCH ps.partyMember pm
+        JOIN FETCH pm.member
+        WHERE ps.stopover IN :stopovers
+    """)
+    List<PaymentStatus> findAllWithPartyMemberAndMemberByStopoverIn(List<Stopover> stopovers);
 }

--- a/src/main/java/com/wap/app2/gachitayo/repository/location/StopoverRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/location/StopoverRepository.java
@@ -1,13 +1,16 @@
 package com.wap.app2.gachitayo.repository.location;
 
-import com.wap.app2.gachitayo.Enum.LocationType;
-import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 
 public interface StopoverRepository extends JpaRepository<Stopover, Long> {
-    Optional<Stopover> findByLocationAndStopoverType(Location location, LocationType stopoverType);
+    @Query("""
+        SELECT s FROM Stopover s JOIN FETCH s.fare WHERE s.id = :partyId
+    """)
+    Optional<Stopover> findStopoverWithFare(@Param("partyId") Long partyId);
 }

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
     @Query(value = """
@@ -15,4 +16,11 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
         WHERE s.stopover_type = 'DESTINATION' AND ST_Distance_Sphere(point(l.longitude, l.latitude), point(:lng, :lat)) <= :radius
         """, nativeQuery = true)
     List<Party> findPartiesWithRadius(@Param("lat") double lat, @Param("lng") double lng, @Param("radius") double radius);
+
+    @Query("""
+    SELECT DISTINCT p FROM Party p
+    JOIN FETCH p.stopovers s
+    WHERE p.id = :partyId
+    """)
+    Optional<Party> findPartyWithStopovers(@Param("partyId") Long partyId);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/FareService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/FareService.java
@@ -17,7 +17,6 @@ public class FareService {
         Fare defaultFare = Fare.builder()
                 .stopover(stopover)
                 .baseFigure(0)
-                .finalFigure(0)
                 .build();
         return fareRepository.save(defaultFare);
     }

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PaymentStatusService {
@@ -20,6 +22,11 @@ public class PaymentStatusService {
                 .stopover(stopover)
                 .build();
         return paymentStatusRepository.save(paymentStatus);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PaymentStatus> findPaymentStatusListByStopoverIn(List<Stopover> stopoverList) {
+        return paymentStatusRepository.findAllWithPartyMemberAndMemberByStopoverIn(stopoverList);
     }
 
     @Transactional

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverFacade.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverFacade.java
@@ -1,16 +1,23 @@
 package com.wap.app2.gachitayo.service.location;
 
+import com.wap.app2.gachitayo.Enum.AdditionalRole;
 import com.wap.app2.gachitayo.Enum.LocationType;
+import com.wap.app2.gachitayo.Enum.PartyMemberRole;
 import com.wap.app2.gachitayo.domain.fare.Fare;
+import com.wap.app2.gachitayo.domain.fare.PaymentStatus;
 import com.wap.app2.gachitayo.domain.location.Location;
 import com.wap.app2.gachitayo.domain.location.Stopover;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.dto.datadto.LocationDto;
+import com.wap.app2.gachitayo.dto.request.FareRequestDto;
 import com.wap.app2.gachitayo.mapper.LocationMapper;
 import com.wap.app2.gachitayo.service.fare.FareService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -66,4 +73,52 @@ public class StopoverFacade {
         return true;
     }
 
+    public void calculateFinalFare(List<FareRequestDto> fareRequestDtoList, List<Stopover> stopoverList) {
+        stopoverService.inputBaseFigure(fareRequestDtoList);
+
+        List<Stopover> sortedStopoverList = stopoverList.stream()
+                .sorted(Comparator.comparingInt(s -> s.getFare() != null ? s.getFare().getBaseFigure() : 0))
+                .toList();
+
+        int prevBaseFigure = 0;
+        for(Stopover stopover : sortedStopoverList) {
+            if (stopover.getStopoverType().equals(LocationType.START)) continue;
+
+            int baseFare = stopover.getFare().getBaseFigure();
+            List<PaymentStatus> psList = stopover.getPaymentStatusList();
+            int numDropOff = psList.size();
+            if (numDropOff == 0) continue;
+
+            int currentFare = baseFare - prevBaseFigure;
+            int expectFinalFare = currentFare / numDropOff;
+            int remainderFare = currentFare % numDropOff;
+
+            if (remainderFare > 0) {
+                prevBaseFigure = (expectFinalFare + remainderFare) * numDropOff;
+            } else {
+                prevBaseFigure = baseFare;
+            }
+
+            for (PaymentStatus ps : psList) {
+                // 최종 결산자는 항상 목적지에 내린다고 가정. 따라서 목적지에서만 Role를 검사하면 됨
+                if(stopover.getStopoverType().equals(LocationType.DESTINATION)){
+                    PartyMemberRole memberRole = ps.getPartyMember().getMemberRole();
+                    switch (memberRole) {
+                        case HOST:
+                            if (!ps.getPartyMember().getAdditionalRole().equals(AdditionalRole.BOOKKEEPER)) break;
+                        case BOOKKEEPER:
+                            ps.setFinalFigure(expectFinalFare);
+                            ps.setPaid(true);
+                            break;
+                        case MEMBER:
+                            ps.setFinalFigure(expectFinalFare + remainderFare);
+                            break;
+                    }
+                    continue;
+                }
+                ps.setFinalFigure(expectFinalFare + remainderFare);
+            }
+            stopoverService.saveStopover(stopover);
+        }
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -1,10 +1,15 @@
 package com.wap.app2.gachitayo.service.location;
 
 import com.wap.app2.gachitayo.domain.location.Stopover;
+import com.wap.app2.gachitayo.dto.request.FareRequestDto;
+import com.wap.app2.gachitayo.error.exception.ErrorCode;
+import com.wap.app2.gachitayo.error.exception.TagogayoException;
 import com.wap.app2.gachitayo.repository.location.StopoverRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -15,5 +20,13 @@ public class StopoverService {
 
     public Stopover saveStopover(Stopover stopover) {
         return stopoverRepository.save(stopover);
+    }
+
+    public void inputBaseFigure(List<FareRequestDto> fareRequestDtoList) {
+        fareRequestDtoList.forEach(fareRequestDto -> {
+            Stopover stopover = stopoverRepository.findById(fareRequestDto.getStopoverId()).orElseThrow(() -> new TagogayoException(ErrorCode.STOPOVER_NOT_FOUND));
+            stopover.getFare().setBaseFigure(fareRequestDto.getFare());
+            stopoverRepository.save(stopover);
+        });
     }
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/location/StopoverService.java
@@ -24,7 +24,7 @@ public class StopoverService {
 
     public void inputBaseFigure(List<FareRequestDto> fareRequestDtoList) {
         fareRequestDtoList.forEach(fareRequestDto -> {
-            Stopover stopover = stopoverRepository.findById(fareRequestDto.getStopoverId()).orElseThrow(() -> new TagogayoException(ErrorCode.STOPOVER_NOT_FOUND));
+            Stopover stopover = stopoverRepository.findStopoverWithFare(fareRequestDto.getStopoverId()).orElseThrow(() -> new TagogayoException(ErrorCode.STOPOVER_NOT_FOUND));
             stopover.getFare().setBaseFigure(fareRequestDto.getFare());
             stopoverRepository.save(stopover);
         });

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyService.java
@@ -24,6 +24,10 @@ public class PartyService {
         return partyRepository.save(party);
     }
 
+    public Party findPartyWithStopovers(Long id) {
+        return partyRepository.findPartyWithStopovers(id).orElseThrow(() -> new TagogayoException(ErrorCode.PARTY_NOT_FOUND));
+    }
+
     @Transactional(readOnly = true)
     public List<Party> findPartiesWithinRadius(double latitude, double longitude, double radius) {
         return partyRepository.findPartiesWithRadius(latitude, longitude, radius);


### PR DESCRIPTION
## 연관된 이슈

> #53 

## 작업 상세

|엔드포인트|메서드|
|---|---|
|`/api/party/{id}/fare`| `POST`|

- 클라이언트로부터 `stopoverId`와 `baseFigure`를 요청 받아 정산 메커니즘 적용해 응답
- 일반적인 경우 `현재 계산할 금액/내린 사람 수` 가 적용됨
- 현재 계산할 금액을 내린 사람 수로 딱 나눠서 떨어지지 않으면 최종 결산자는 소액 감면, 나머지는 소액 부담하도록 구현
- 레포지토리 단에서 `JOIN FETCH`를 적용해 중복되는 `JOIN`절이나 불필요한 쿼를 줄임

(글로 어떻게 표현해야 할지 몰라서 대충 적었습니다. 회의 때 나온 요구사항대로 구현되어 있습니다.)

## 테스트

- 요청

![금액 반영](https://github.com/user-attachments/assets/a1a6f401-d56c-4d47-bcdb-69a5d912af0e)

- 응답

![금액 반영 응답 1](https://github.com/user-attachments/assets/ed8bd5f8-9122-4510-917b-cbc958f3cf5b)
![금액 반영 응답 2](https://github.com/user-attachments/assets/c7975824-ebac-42fd-8938-d726251b261b)

- 최종 결산자 소액 감면 및 나머지 유저 소액 부담

![금액 반영 나눠서 떨어지지 않는 경우](https://github.com/user-attachments/assets/6fc1cef0-1c18-49fb-9568-659228879729)

- 응답

![금액 반영 나눠서 떨어지지 않는 경우 응답 1](https://github.com/user-attachments/assets/b210661c-c849-4a3a-94c8-582bf58df218)
![금액 반영 나눠서 떨어지지 않는 경우 응답 2](https://github.com/user-attachments/assets/e33785d5-5886-4e46-a3e7-7ba2c208d2b2)
![금액 반영 나눠서 떨어지지 않는 경우 응답 3](https://github.com/user-attachments/assets/6e10a408-f645-4d57-97b6-8511f48b544d)

---
### Close: #53 