### PR TITLE
Feature/85 정산 확인 반영

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/party/PartyController.java
@@ -50,4 +50,9 @@ public class PartyController {
     public ResponseEntity<?> reflectCalculatedFare(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody List<FareRequestDto> requestDtoList) {
         return partyFacade.reflectCalculatedFare(id, memberDetails.getUsername(), requestDtoList);
     }
+
+    @PatchMapping("/{id}/fare/confirm")
+    public ResponseEntity<?> reflectConfirmedFare(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable("id") Long id, @RequestBody FareConfirmRequestDto requestDto) {
+        return partyFacade.reflectPayment(id, memberDetails.getUsername(), requestDto);
+    }
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/FareConfirmRequestDto.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/FareConfirmRequestDto.java
@@ -1,0 +1,16 @@
+package com.wap.app2.gachitayo.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FareConfirmRequestDto {
+    @JsonProperty("party_member_id")
+    Long partyMemberId;
+    @JsonProperty("stopover_id")
+    Long stopoverId;
+}

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -29,13 +29,15 @@ public enum ErrorCode {
     EXCEED_PARTY_MEMBER(HttpStatus.CONFLICT.value(), "PARTY-409-1", "인원이 가득 찬 파티입니다."),
     ALREADY_PARTY_MEMBER(HttpStatus.CONFLICT.value(), "PARTY-409-2", "이미 속한 파티입니다."),
     NOT_MATCH_GENDER_OPTION(HttpStatus.CONFLICT.value(), "PARTY-409-3", "파티 성별 옵션에 맞지 않는 유저입니다."),
-    NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아닙니다."),
+    NOT_IN_PARTY(HttpStatus.FORBIDDEN.value(), "PARTY-403-4", "해당 파티의 유저가 아니거나 찾을 수 없습니다."),
     NOT_HOST(HttpStatus.FORBIDDEN.value(), "PARTY-403-5", "해당 파티의 방장이 아닙니다."),
-    PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "PARTY-404-6", "해당 파티의 유저가 아니거나 찾을 수 없습니다."),
-    NOT_BOOKKEEPER(HttpStatus.FORBIDDEN.value(), "PARTY-403-7", "해당 파티의 최종 결산자가 아닙니다."),
+    NOT_BOOKKEEPER(HttpStatus.FORBIDDEN.value(), "PARTY-403-6", "해당 파티의 최종 결산자가 아닙니다."),
 
     //Stopover
     STOPOVER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "STOPOVER-404-1", "존재하지 않는 경유지입니다."),
+
+    //PaymentStatus
+    PAYMENT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "PAYMENT_STATUS-404-1", "해당 유저에 대한 결제 정보를 찾을 수 없습니다."),
 
     //Review
     ALREADY_REVIEW(HttpStatus.CONFLICT.value(), "REVIEW-409-1", "이미 리뷰를 작성하였습니다."),

--- a/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
+++ b/src/main/java/com/wap/app2/gachitayo/repository/party/PartyMemberRepository.java
@@ -6,11 +6,12 @@ import com.wap.app2.gachitayo.domain.party.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
     boolean existsByPartyAndMember(Party party, Member member);
 
     List<PartyMember> findAllByParty(Party party);
 
-    PartyMember findByPartyAndMember(Party party, Member member);
+    Optional<PartyMember> findByPartyAndMember(Party party, Member member);
 }

--- a/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/fare/PaymentStatusService.java
@@ -30,6 +30,12 @@ public class PaymentStatusService {
     }
 
     @Transactional
+    public void updatePaidStatus(PaymentStatus targetPaymentStatus, boolean paid) {
+        targetPaymentStatus.setPaid(paid);
+        paymentStatusRepository.save(targetPaymentStatus);
+    }
+
+    @Transactional
     public boolean updateStopover(PartyMember partyMember, Stopover newStopover) {
         PaymentStatus existingPaymentStatus = paymentStatusRepository.findByPartyMember(partyMember);
         if(existingPaymentStatus == null) return false;

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
@@ -208,7 +208,6 @@ public class PartyFacade {
         return ResponseEntity.ok(partyDtos);
     }
 
-    @Transactional
     public ResponseEntity<?> electBookkeeper(Long partyId, String hostEmail, Long targetPartyMemberId) {
         Party party = verifyPartyAndPartyMember(hostEmail, partyId, PartyMemberRole.HOST);
 
@@ -232,7 +231,6 @@ public class PartyFacade {
         return ResponseEntity.ok(party.getPartyMemberList().stream().map(this::toPartyMemberResponseDto).toList());
     }
 
-    @Transactional
     public ResponseEntity<?> reflectCalculatedFare(Long partyId, String bookkeeperEmail, List<FareRequestDto> requestDtoList) {
         Party party = verifyPartyAndPartyMember(bookkeeperEmail, partyId, PartyMemberRole.BOOKKEEPER);
 
@@ -246,6 +244,34 @@ public class PartyFacade {
         Map<Long, List<PaymentStatus>> paymentStatusMap = paymentStatusList.stream()
                 .collect(Collectors.groupingBy(ps -> ps.getStopover().getId()));
 
+        return toFinalPaymentStatusResponseDto(paymentStatusMap, updatedParty);
+    }
+
+    public ResponseEntity<?> reflectPayment(Long partyId, String bookkeeperEmail, FareConfirmRequestDto requestDto) {
+        Party party = verifyPartyAndPartyMember(bookkeeperEmail, partyId, PartyMemberRole.BOOKKEEPER);
+
+        Stopover targetStopover = party.getStopovers().stream()
+                .filter(s -> s.getId().equals(requestDto.getStopoverId())).findFirst().orElseThrow(() -> new TagogayoException(ErrorCode.STOPOVER_NOT_FOUND));
+        PaymentStatus targetStatus = targetStopover.getPaymentStatusList().stream()
+                .filter(ps -> ps.getPartyMember().getId().equals(requestDto.getPartyMemberId())).findFirst().orElseThrow(() -> new TagogayoException(ErrorCode.PAYMENT_STATUS_NOT_FOUND));
+
+        if (targetStatus.isPaid()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        paymentStatusService.updatePaidStatus(targetStatus, true);
+
+        // Party + Stopover
+        Party updatedParty = partyService.findPartyWithStopovers(partyId);
+        // PaymentStatus + PartyMember + Member
+        List<PaymentStatus> paymentStatusList = paymentStatusService.findPaymentStatusListByStopoverIn(updatedParty.getStopovers());
+        Map<Long, List<PaymentStatus>> paymentStatusMap = paymentStatusList.stream()
+                .collect(Collectors.groupingBy(ps -> ps.getStopover().getId()));
+
+        return toFinalPaymentStatusResponseDto(paymentStatusMap, updatedParty);
+    }
+
+    private ResponseEntity<?> toFinalPaymentStatusResponseDto(Map<Long, List<PaymentStatus>> paymentStatusMap, Party updatedParty) {
         List<FinalPaymentStatusResponseDto> responseDtoList = updatedParty.getStopovers().stream()
                 .filter(stopover -> !stopover.getStopoverType().equals(LocationType.START))
                 .flatMap(stopover -> {
@@ -313,7 +339,6 @@ public class PartyFacade {
         if (hostMember == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
 
         PartyMember partyMember = partyMemberService.getPartyMemberByPartyAndMember(party, hostMember);
-        if (partyMember == null) throw new TagogayoException(ErrorCode.NOT_IN_PARTY);
         validatePartyMemberRole(partyMember, role);
 
         return party;

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyFacade.java
@@ -122,7 +122,6 @@ public class PartyFacade {
         if (participant == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
 
         PartyMember participantMember = partyMemberService.getPartyMemberByPartyAndMember(party, participant);
-        if (participantMember == null) throw new TagogayoException(ErrorCode.NOT_IN_PARTY);
 
         // 3. Stopover 찾거나 생성
         Stopover stopover = stopoverFacade.findOrCreateStopover(party, requestDto.getLocation());
@@ -158,7 +157,6 @@ public class PartyFacade {
             if (member == null) throw new TagogayoException(ErrorCode.MEMBER_NOT_FOUND);
 
             PartyMember partyMember = partyMemberService.getPartyMemberByPartyAndMember(party, member);
-            if (partyMember == null) throw new TagogayoException(ErrorCode.NOT_IN_PARTY);
 
             isUpdatedPaymentStatus = paymentStatusService.updateStopover(partyMember, stopover);
         }

--- a/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/party/PartyMemberService.java
@@ -39,7 +39,7 @@ public class PartyMemberService {
 
     @Transactional(readOnly = true)
     public PartyMember getPartyMemberByPartyAndMember(Party party, Member member) {
-        return partyMemberRepository.findByPartyAndMember(party, member);
+        return partyMemberRepository.findByPartyAndMember(party, member).orElseThrow(() -> new TagogayoException(ErrorCode.NOT_IN_PARTY));
     }
 
     @Transactional(readOnly = true)
@@ -51,7 +51,7 @@ public class PartyMemberService {
 
     @Transactional(readOnly = true)
     public PartyMember getPartyMemberById(Long id) {
-        return partyMemberRepository.findById(id).orElseThrow(() -> new TagogayoException(ErrorCode.PARTY_MEMBER_NOT_FOUND));
+        return partyMemberRepository.findById(id).orElseThrow(() -> new TagogayoException(ErrorCode.NOT_IN_PARTY));
     }
 
     @Transactional


### PR DESCRIPTION
## 연관된 이슈

> #85 

## 작업 상세

|엔드포인트|메서드|
|---|---|
|`/api/party/{id}/fare/confirm`|`PATCH`|

- 파티 멤버 id 와 경유지 id 에 연결된 결제 정보 업데이트
- stopover_id에 내리는 party_member_id에 해당하는 유저의 지불 여부 `is_paid`를 `true`로 반영

## 테스트

- 반영 전 DB

![정산 완료 반영 전 DB](https://github.com/user-attachments/assets/748bebcc-0ad1-4559-8482-b9e6cf8c7d8a)

- 요청

![정산 확인 요청](https://github.com/user-attachments/assets/9bf6937b-c0be-49b9-87af-86e55223dadc)

- 응답

![정산 확인 응답 1](https://github.com/user-attachments/assets/903a66f8-ded8-4b65-8f1c-0f1c0bdc86f1)
![정산 확인 응답 2](https://github.com/user-attachments/assets/48845dbd-a31a-4b20-8ea1-c6602b65287f)
![정산 확인 응답 3](https://github.com/user-attachments/assets/916b1af8-588f-4678-b4e8-c2f2bbf4abcb)

- 반영 후 DB

![정산 확인 반영 후 DB](https://github.com/user-attachments/assets/4afea5a5-84a9-4974-a57b-86f693da636c)

---
### Closes: #85 
