### PR TITLE
Refactor/98 리뷰 코멘트를 태그형식으로 변경

### DIFF
--- a/src/main/java/com/wap/app2/gachitayo/Enum/ReviewTag.java
+++ b/src/main/java/com/wap/app2/gachitayo/Enum/ReviewTag.java
@@ -1,0 +1,35 @@
+package com.wap.app2.gachitayo.Enum;
+
+import com.wap.app2.gachitayo.error.exception.ErrorCode;
+import com.wap.app2.gachitayo.error.exception.TagogayoException;
+
+import java.util.Arrays;
+
+public enum ReviewTag {
+    TIME_KEEPER("#시간 엄수"),
+    GOOD_COMMUNICATION("#소통 원할"),
+    KINDNESS("#친절한 태도"),
+    RESPECT("#상대 존중"),
+    LOCATION_CARE("#위치 배려"),
+    SATISFIED("#탑승 만족"),
+    GOOD_MANNER("#굿 매너"),
+    RE_RIDE_HOPE("#재탑승 희망"),
+    MANNER_PAYER("#매너 정산러");
+
+    private final String value;
+
+    ReviewTag(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ReviewTag fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(tag -> tag.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new TagogayoException(ErrorCode.TAG_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/wap/app2/gachitayo/controller/review/ReviewController.java
+++ b/src/main/java/com/wap/app2/gachitayo/controller/review/ReviewController.java
@@ -17,7 +17,9 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping
-    public ResponseEntity<?> addMemberReview(@PathVariable String email, @AuthenticationPrincipal MemberDetails memberDetails, @RequestBody @Validated ReviewMemberRequest request) {
+    public ResponseEntity<?> addMemberReview(@PathVariable String email,
+                                             @AuthenticationPrincipal MemberDetails memberDetails,
+                                             @RequestBody @Validated ReviewMemberRequest request) {
         return reviewService.addMemberReview(memberDetails.getUsername(), email, request);
     }
 

--- a/src/main/java/com/wap/app2/gachitayo/domain/review/Review.java
+++ b/src/main/java/com/wap/app2/gachitayo/domain/review/Review.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Entity
 @Getter
 @Setter
@@ -36,6 +39,8 @@ public class Review {
     @DecimalMax("5.0")
     private double score;
 
-    @Column(length = 2100) // 최대 500자 검증
-    private String contents;
+    @ElementCollection
+    @CollectionTable(name = "review_tags", joinColumns = @JoinColumn(name = "review_id"))
+    @Column(name = "tag")
+    private Set<String> tags = new HashSet<>();
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/request/ReviewMemberRequest.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/request/ReviewMemberRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 
+import java.util.Set;
+
 public record ReviewMemberRequest(
         @NotBlank
         Long party_id,
@@ -16,7 +18,6 @@ public record ReviewMemberRequest(
         double score,
 
         @NotNull
-        @Length(max = 500)
-        String contents
+        Set<String> tags
 ) {
 }

--- a/src/main/java/com/wap/app2/gachitayo/dto/response/ReviewListResponse.java
+++ b/src/main/java/com/wap/app2/gachitayo/dto/response/ReviewListResponse.java
@@ -3,6 +3,7 @@ package com.wap.app2.gachitayo.dto.response;
 import com.wap.app2.gachitayo.domain.review.Review;
 
 import java.util.List;
+import java.util.Set;
 
 public record ReviewListResponse(
         int count,
@@ -11,13 +12,13 @@ public record ReviewListResponse(
     public record MemberReviewResponse(
         String name,
         Double score,
-        String contents
+        Set<String> tags
     ) {
         public static MemberReviewResponse from(Review review) {
             return new MemberReviewResponse(
                     review.getAuthor().getName(),
                     review.getScore(),
-                    review.getContents()
+                    review.getTags()
             );
         }
     }

--- a/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
+++ b/src/main/java/com/wap/app2/gachitayo/error/exception/ErrorCode.java
@@ -41,8 +41,10 @@ public enum ErrorCode {
 
     //Review
     ALREADY_REVIEW(HttpStatus.CONFLICT.value(), "REVIEW-409-1", "이미 리뷰를 작성하였습니다."),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "REVIEW-409-2", "존재하지 않는 태그입니다."),
 
-    INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "Internal Server Error");
+    INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "Internal Server Error"),
+    ;
 
     private final int status;
     private final String code;

--- a/src/main/java/com/wap/app2/gachitayo/service/review/ReviewService.java
+++ b/src/main/java/com/wap/app2/gachitayo/service/review/ReviewService.java
@@ -1,5 +1,6 @@
 package com.wap.app2.gachitayo.service.review;
 
+import com.wap.app2.gachitayo.Enum.ReviewTag;
 import com.wap.app2.gachitayo.domain.member.Member;
 import com.wap.app2.gachitayo.domain.party.Party;
 import com.wap.app2.gachitayo.domain.review.Review;
@@ -38,6 +39,10 @@ public class ReviewService {
 
         if (isExistReview(party, author, target)) {
             throw new TagogayoException(ErrorCode.ALREADY_REVIEW);
+        }
+
+        for (String tag : request.tags()) {
+            ReviewTag.fromValue(tag);
         }
 
         Review review = createReview(author, target, party, request);
@@ -91,7 +96,7 @@ public class ReviewService {
                 .target(target)
                 .party(party)
                 .score(request.score())
-                .contents(request.contents())
+                .tags(request.tags())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #98

## 📝작업 내용

> 사용자 리뷰를 코멘트 방식에서, 태그 선택형으로 변경하였습니다
> 태그는 문자형 리스트로 받습니다.
> 현재 존재하는 해시태그 목록은, "#시간 엄수, #소통 원할, #친절한 태도, #상대 존중, #위치 배려, #탑승 만족, #굿 매너, #재탑승 희망, #매너 정산러" 입니다.
> 클라이언트는 해시태그 문자를 매핑해서 사용하면됩니다.

## 중점적으로 리뷰받고 싶은 부분(선택)


## 논의하고 싶은 부분(선택)
> 구현의 편의성때문에 Enum 방식을 채택했습니다. 확장성이 안좋다는 단점때문에 추후 변경할 수도 있습니다.

## 🫡 참고사항